### PR TITLE
Implement stream balance checks, withdrawals, refunds, and signed updates

### DIFF
--- a/contracts/STX-Dripstream.clar
+++ b/contracts/STX-Dripstream.clar
@@ -91,3 +91,104 @@
     delta
     )
 )
+
+
+;; Check balance for a party involved in a stream
+(define-read-only (balance-of (stream-id uint) (who principal))
+    (let (
+        (stream (unwrap! (map-get? streams stream-id) u0))
+        (block-delta (calculate-block-delta (get timeframe stream)))
+        (recipient-balance (* block-delta (get payment-per-block stream)))
+    )
+    (if (is-eq who (get recipient stream))
+        (- recipient-balance (get withdrawn-balance stream))
+        (if (is-eq who (get sender stream))
+            (- (get balance stream) recipient-balance)
+            u0
+            )
+        )
+    )
+)
+
+;; Withdraw received tokens
+(define-public (withdraw (stream-id uint))
+    (let (
+        (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))
+        (balance (balance-of stream-id contract-caller))
+    )
+        (asserts! (is-eq contract-caller (get recipient stream)) ERR_UNAUTHORIZED)
+        (map-set streams stream-id
+            (merge stream {withdrawn-balance: (+ (get withdrawn-balance stream) balance)})
+        )
+        (try! (as-contract (stx-transfer? balance tx-sender (get recipient stream))))
+        (ok balance)
+     )
+)
+
+;; Withdraw excess locked tokens
+(define-public (refund
+    (stream-id uint)
+  )
+  (let (
+    (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))
+    (balance (balance-of stream-id (get sender stream)))
+  )
+    (asserts! (is-eq contract-caller (get sender stream)) ERR_UNAUTHORIZED)
+    (asserts! (< (get stop-block (get timeframe stream)) stacks-block-height) ERR_STREAM_STILL_ACTIVE)
+    (map-set streams stream-id (merge stream {
+        balance: (- (get balance stream) balance),
+      }
+    ))
+    (try! (as-contract (stx-transfer? balance tx-sender (get sender stream))))
+    (ok balance)
+  )
+)
+
+;; Get hash of stream
+(define-read-only (hash-stream
+    (stream-id uint)
+    (new-payment-per-block uint)
+    (new-timeframe (tuple (start-block uint) (stop-block uint)))
+  )
+  (let (
+    (stream (unwrap! (map-get? streams stream-id) (sha256 0)))
+    (msg (concat (concat (unwrap-panic (to-consensus-buff? stream)) (unwrap-panic (to-consensus-buff? new-payment-per-block))) (unwrap-panic (to-consensus-buff? new-timeframe))))
+  )
+    (sha256 msg)
+  )
+)
+
+;; Signature verification
+(define-read-only (validate-signature (hash (buff 32)) (signature (buff 65)) (signer principal))
+        (is-eq 
+          (principal-of? (unwrap! (secp256k1-recover? hash signature) false)) 
+          (ok signer)
+        )
+)
+
+;; Update stream configuration
+(define-public (update-details
+    (stream-id uint)
+    (payment-per-block uint)
+    (timeframe (tuple (start-block uint) (stop-block uint)))
+    (signer principal)
+    (signature (buff 65))
+  )
+  (let (
+    (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))  
+  )
+    (asserts! (validate-signature (hash-stream stream-id payment-per-block timeframe) signature signer) ERR_INVALID_SIGNATURE)
+    (asserts!
+      (or
+        (and (is-eq (get sender stream) contract-caller) (is-eq (get recipient stream) signer))
+        (and (is-eq (get sender stream) signer) (is-eq (get recipient stream) contract-caller))
+      )
+      ERR_UNAUTHORIZED
+    )
+    (map-set streams stream-id (merge stream {
+        payment-per-block: payment-per-block,
+        timeframe: timeframe
+    }))
+    (ok true)
+  )
+)


### PR DESCRIPTION

###  Pull Request Description

**Title:** `Add stream balance, withdrawal, refund, and secure update functionality`

**Description:**

This PR expands the functionality of the streaming STX payment protocol by implementing balance access, fund withdrawals, refunding, and secure update operations:

#### ✅ Key Additions:

* **`balance-of`**: A read-only function to determine the available balance for either the sender or recipient, based on time elapsed and withdrawn amounts.

* **`withdraw`**: Allows the recipient to withdraw available STX, updating the internal withdrawn balance and transferring funds from the contract.

* **`refund`**: Enables the sender to reclaim unused STX from the stream **after** the stream has ended. Validates stream state before refunding.

* **`hash-stream`**: Creates a SHA-256 hash of proposed updated stream parameters, used in the signature verification process.

* **`validate-signature`**: Verifies ECDSA signatures over stream configuration updates using `secp256k1-recover?`.

* **`update-details`**: Enables secure off-chain approval of stream configuration changes (payment-per-block and timeframe) by requiring a valid signature from the counterparty (either sender or recipient).

#### 🔐 Security Considerations:

* Verifies identity via signature recovery and ensures only counterparties may approve updates.
* Prevents unauthorized withdrawals and refunds with strict role checks.
* Ensures refunds only happen after the stream's stop block.

These updates finalize the core protocol logic, allowing fully interactive and permissioned payment stream lifecycle management.

---